### PR TITLE
Added note to readme that Python and Mercurial are required

### DIFF
--- a/README
+++ b/README
@@ -5,6 +5,8 @@ from git.
 
 * Dependencies *
 
+You'll need Mercurial and Python installed and in your $PATH.
+
 If this is a fresh checkout run
 
   $ git submodule init


### PR DESCRIPTION
You can't do the fast-export without them.
