### PR TITLE
Export the variable PYTHON

### DIFF
--- a/bin/git-hg
+++ b/bin/git-hg
@@ -2,6 +2,7 @@
 
 if which python2 >&/dev/null; then
   PYTHON=python2
+  export PYTHON
 fi
 
 set -e


### PR DESCRIPTION
It makes no sense to define PYTHON without exporting it as an environment variable.
