### PR TITLE
fixing markdown error

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,7 +32,7 @@ Alternatively you can execute
         $ sudo make install
 
 to install the script and all required fast-export files in `/usr/local` (you
-can change the destination by passing eg `PREFIX=/usr` to *both* `make'
+can change the destination by passing eg `PREFIX=/usr` to *both* `make`
 invocations)
 
 ## Usage ##


### PR DESCRIPTION
Incorrect closing character around make was causing the README document not to
render correctly.