### PR TITLE
git-hg: fix variable typo

### DIFF
--- a/bin/git-hg
+++ b/bin/git-hg
@@ -81,7 +81,7 @@ function git-hg-clone {
     else
         CHECKOUT=$2
     fi
-    if [[ -e $CHECKOUT && "$(ls -A $f)" ]]; then
+    if [[ -e $CHECKOUT && "$(ls -A "$CHECKOUT")" ]]; then
 	echo "error: $CHECKOUT exists"
 	exit 1
     fi


### PR DESCRIPTION
There is no $f variable in this script.  It seems to have meant to
look at the $CHECKOUT variable instead.